### PR TITLE
Add per-store repasse calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ valor final destinado às lojas (PDVs). O cálculo é descrito nos campos abaixo
   "formula_repasse_pdvs": "(total_geral - total_comissoes) - total_taxas_pdvs"
 }
 ```
+
+Cada loja também possui um repasse individual disponível no campo `repasse_loja`,
+onde a chave é o `id` da loja e o valor representa o montante repassado após as
+comissões e as taxas do PDV.


### PR DESCRIPTION
## Summary
- compute repasse per store in `FechamentoEventoService`
- document new `repasse_loja` field in README

## Testing
- `npx tsc -p tsconfig.json`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846e745fd0c8329b79f72b6e4b9e35e